### PR TITLE
#2 Fix wrong directory on package gopherapi

### DIFF
--- a/cmd/gopherapi/main.go
+++ b/cmd/gopherapi/main.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/friendsofgo/gopher-api/pkg/storage/inmem"
+	"github.com/friendsofgo/gopherapi/pkg/storage/inmem"
 
-	sample "github.com/friendsofgo/gopher-api/cmd/sample-data"
-	gopher "github.com/friendsofgo/gopher-api/pkg"
+	sample "github.com/friendsofgo/gopherapi/cmd/sample-data"
+	gopher "github.com/friendsofgo/gopherapi/pkg"
 
-	"github.com/friendsofgo/gopher-api/pkg/server"
+	"github.com/friendsofgo/gopherapi/pkg/server"
 )
 
 func main() {

--- a/cmd/sample-data/data.go
+++ b/cmd/sample-data/data.go
@@ -1,7 +1,7 @@
 package sample
 
 import (
-	gopher "github.com/friendsofgo/gopher-api/pkg"
+	gopher "github.com/friendsofgo/gopherapi/pkg"
 )
 
 var Gophers = map[string]*gopher.Gopher{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
-module github.com/friendsofgo/gopher-api
+module github.com/friendsofgo/gopherapi
 
-require (
-	github.com/aperezg/monster v0.0.0-20190201085025-648ece19f831
-	github.com/gorilla/mux v1.7.0
-)
+require github.com/gorilla/mux v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,2 @@
-github.com/aperezg/monster v0.0.0-20190201085025-648ece19f831 h1:zcVrTQ22nmJ1+0sp9Lc7OuAMkNqqbEy/3OKXiWB2ods=
-github.com/aperezg/monster v0.0.0-20190201085025-648ece19f831/go.mod h1:59SPFI3k23yeORvJqB1py+ZSdAgQKVaPAMZ0ZUWvZyo=
-github.com/google/jsonapi v0.0.0-20181016150055-d0428f63eb51/go.mod h1:XSx4m2SziAqk9DXY9nz659easTq4q6TyrpYd9tHSm0g=
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
-github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	gopher "github.com/friendsofgo/gopher-api/pkg"
+	gopher "github.com/friendsofgo/gopherapi/pkg"
 
 	"github.com/gorilla/mux"
 )

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -8,9 +8,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	sample "github.com/friendsofgo/gopher-api/cmd/sample-data"
-	gopher "github.com/friendsofgo/gopher-api/pkg"
-	"github.com/friendsofgo/gopher-api/pkg/storage/inmem"
+	sample "github.com/friendsofgo/gopherapi/cmd/sample-data"
+	gopher "github.com/friendsofgo/gopherapi/pkg"
+	"github.com/friendsofgo/gopherapi/pkg/storage/inmem"
 )
 
 func TestFetchGophers(t *testing.T) {

--- a/pkg/storage/inmem/repository.go
+++ b/pkg/storage/inmem/repository.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	gopher "github.com/friendsofgo/gopher-api/pkg"
+	gopher "github.com/friendsofgo/gopherapi/pkg"
 )
 
 type gopherRepository struct {


### PR DESCRIPTION
Related with issue #2, fix all the directories with wrong path, and update the go modules with new package path.